### PR TITLE
Change timeout behaviour

### DIFF
--- a/public/js/pix.js
+++ b/public/js/pix.js
@@ -1,18 +1,24 @@
 var socket = io();
+var timeout;
 
 function pickArt(altTag) {
   artPiece = altTag;
   console.log('art picked' + artPiece);
   socket.emit('artPiece', artPiece);
-  $('.gallery').append('<img src="public/images/' + artPiece + '-lrg.gif">');
-  setTimeout(function() {
+  $('.gallery').html('<img src="public/images/' + artPiece + '-lrg.gif">');
+  timeout = setTimeout(function() {
     $('.gallery').empty();
+    timeout = undefined;
   }, 2000)
 };
 
 $('.galleryItem').click(function(e){
     e.preventDefault();
     var alt = $(this).children("img").attr("alt");
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
 
     pickArt(alt);
 });


### PR DESCRIPTION
When I was playing with it I noticed the images would stack and then all disappear at once if I clicked really quickly. This PR makes it so that it only has the timeout for the most recent change and only shows one image at once.